### PR TITLE
Add custom request headers

### DIFF
--- a/src/orion.ts
+++ b/src/orion.ts
@@ -7,6 +7,8 @@ export class Orion {
 	protected static prefix: string;
 	protected static authDriver: AuthDriver;
 	protected static token: string | null = null;
+	// Custom headers that should be sent with every request made by Orion's HttpClient
+	protected static headers: Record<string, string> = {};
 
 	protected static httpClientConfig: AxiosRequestConfig;
 	protected static makeHttpClientCallback: (() => AxiosInstance) | null = null;
@@ -72,6 +74,39 @@ export class Orion {
 		return Orion;
 	}
 
+	/**
+	 * Set a single custom header that will be sent with every request.
+	 *
+	 * @param key   Header name
+	 * @param value Header value
+	 */
+	public static setHeader(key: string, value: string): Orion {
+		Orion.headers[key] = value;
+		Orion.httpClientConfig = Orion.buildHttpClientConfig();
+
+		return Orion;
+	}
+
+	/**
+	 * Replace the currently configured custom headers with the provided headers object.
+	 * This can be used to set multiple headers at once.
+	 *
+	 * @param headers An object whose keys are header names and values are header values
+	 */
+	public static setHeaders(headers: Record<string, string>): Orion {
+		Orion.headers = Object.assign({}, headers);
+		Orion.httpClientConfig = Orion.buildHttpClientConfig();
+
+		return Orion;
+	}
+
+	/**
+	 * Get the currently configured custom headers.
+	 */
+	public static getHeaders(): Record<string, string> {
+		return Object.assign({}, Orion.headers);
+	}
+
 	public static getToken(): string | null {
 		return Orion.token;
 	}
@@ -106,13 +141,16 @@ export class Orion {
 	protected static buildHttpClientConfig(): AxiosRequestConfig {
 		const config: AxiosRequestConfig = {
 			withCredentials: Orion.getAuthDriver() === AuthDriver.Sanctum,
+			headers: {},
 		};
 
+		// Include Authorization header if token is present
 		if (Orion.getToken()) {
-			config.headers = {
-				Authorization: `Bearer ${Orion.getToken()}`,
-			};
+			config.headers!['Authorization'] = `Bearer ${Orion.getToken()}`;
 		}
+
+		// Merge user-defined custom headers (these may override the Authorization header if user chooses)
+		config.headers = Object.assign(config.headers!, Orion.headers);
 
 		return config;
 	}

--- a/tests/unit/orion.test.ts
+++ b/tests/unit/orion.test.ts
@@ -44,6 +44,26 @@ describe('Orion tests', () => {
 		expect(Orion.getToken()).toBeNull();
 	});
 
+	test('setting single custom header', () => {
+		Orion.setHeader('x-custom-header', 'header value');
+
+		expect(Orion.getHeaders()).toEqual({
+			'x-custom-header': 'header value',
+		});
+	});
+
+	test('setting multiple custom headers', () => {
+		Orion.setHeaders({
+			'x-custom-header': 'header value',
+			'x-custom-header2': 'header value2',
+		});
+
+		expect(Orion.getHeaders()).toEqual({
+			'x-custom-header': 'header value',
+			'x-custom-header2': 'header value2',
+		});
+	});
+
 	test('appending slash to the end when getting api url', () => {
 		Orion.setBaseUrl('https://example.com/api');
 


### PR DESCRIPTION
Add `setHeader` and `setHeaders` methods to allow developers to include custom headers in all HTTP requests.

---
<a href="https://cursor.com/background-agent?bcId=bc-d9b1167f-831f-41c1-b4cd-f1b31f1003f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d9b1167f-831f-41c1-b4cd-f1b31f1003f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

