### PR TITLE
Add custom request headers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@tailflow/laravel-orion",
-	"version": "4.0.0",
+	"version": "4.1.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@tailflow/laravel-orion",
-			"version": "4.0.0",
+			"version": "4.1.0",
 			"license": "MIT",
 			"dependencies": {
 				"axios": "^1.6.0"

--- a/src/orion.ts
+++ b/src/orion.ts
@@ -7,6 +7,7 @@ export class Orion {
 	protected static prefix: string;
 	protected static authDriver: AuthDriver;
 	protected static token: string | null = null;
+	protected static customHeaders: Record<string, string> = {};
 
 	protected static httpClientConfig: AxiosRequestConfig;
 	protected static makeHttpClientCallback: (() => AxiosInstance) | null = null;
@@ -76,6 +77,28 @@ export class Orion {
 		return Orion.token;
 	}
 
+	public static setHeader(name: string, value: string): Orion {
+		Orion.customHeaders[name] = value;
+		Orion.httpClientConfig = Orion.buildHttpClientConfig();
+		return Orion;
+	}
+
+	public static setHeaders(headers: Record<string, string>): Orion {
+		Orion.customHeaders = { ...Orion.customHeaders, ...headers };
+		Orion.httpClientConfig = Orion.buildHttpClientConfig();
+		return Orion;
+	}
+
+	public static getCustomHeaders(): Record<string, string> {
+		return { ...Orion.customHeaders };
+	}
+
+	public static clearHeaders(): Orion {
+		Orion.customHeaders = {};
+		Orion.httpClientConfig = Orion.buildHttpClientConfig();
+		return Orion;
+	}
+
 	public static getHttpClientConfig(): AxiosRequestConfig {
 		return this.httpClientConfig;
 	}
@@ -108,10 +131,10 @@ export class Orion {
 			withCredentials: Orion.getAuthDriver() === AuthDriver.Sanctum,
 		};
 
+		config.headers = { ...Orion.customHeaders };
+
 		if (Orion.getToken()) {
-			config.headers = {
-				Authorization: `Bearer ${Orion.getToken()}`,
-			};
+			config.headers.Authorization = `Bearer ${Orion.getToken()}`;
 		}
 
 		return config;

--- a/tests/integration/drivers/default/server.ts
+++ b/tests/integration/drivers/default/server.ts
@@ -32,6 +32,12 @@ export default function makeServer() {
 				return [];
 			});
 
+			// Generic test endpoint for header testing
+			this.get('/api/test-endpoint', () => ({ success: true }));
+			this.post('/api/test-endpoint', () => ({ success: true }));
+			this.patch('/api/test-endpoint', () => ({ success: true }));
+			this.del('/api/test-endpoint', () => ({ success: true }));
+
 			this.get('/api/posts');
 
 			this.post('/api/posts', function (schema: any, request) {

--- a/tests/integration/orion.test.ts
+++ b/tests/integration/orion.test.ts
@@ -37,4 +37,88 @@ describe('Orion tests', () => {
 		const requests = server.pretender.handledRequests;
 		expect(requests).toHaveLength(0);
 	});
+
+	test('custom headers are sent with requests', async () => {
+		Orion.init('https://api-mock.test', 'api', AuthDriver.Default);
+		Orion.clearHeaders();
+		Orion.setHeaders({
+			'x-custom-header': 'custom-value',
+			'x-api-version': 'v2'
+		});
+
+		const httpClient = Orion.makeHttpClient();
+		await httpClient.get('/test-endpoint');
+
+		const requests = server.pretender.handledRequests;
+		expect(requests).toHaveLength(1);
+		expect(requests[0].requestHeaders).toMatchObject({
+			'x-custom-header': 'custom-value',
+			'x-api-version': 'v2'
+		});
+	});
+
+	test('custom headers work with authorization token', async () => {
+		Orion.init('https://api-mock.test', 'api', AuthDriver.Default, 'test-token');
+		Orion.clearHeaders();
+		Orion.setHeaders({
+			'x-custom-header': 'custom-value',
+			'x-api-version': 'v2'
+		});
+
+		const httpClient = Orion.makeHttpClient();
+		await httpClient.get('/test-endpoint');
+
+		const requests = server.pretender.handledRequests;
+		expect(requests).toHaveLength(1);
+		expect(requests[0].requestHeaders).toMatchObject({
+			'x-custom-header': 'custom-value',
+			'x-api-version': 'v2',
+			'Authorization': 'Bearer test-token'
+		});
+	});
+
+	test('custom headers are sent with POST requests', async () => {
+		Orion.init('https://api-mock.test', 'api', AuthDriver.Default);
+		Orion.clearHeaders();
+		Orion.setHeader('x-custom-header', 'post-value');
+
+		const httpClient = Orion.makeHttpClient();
+		await httpClient.post('/test-endpoint', { data: 'test' });
+
+		const requests = server.pretender.handledRequests;
+		expect(requests).toHaveLength(1);
+		expect(requests[0].requestHeaders).toMatchObject({
+			'x-custom-header': 'post-value'
+		});
+	});
+
+	test('custom headers are sent with PATCH requests', async () => {
+		Orion.init('https://api-mock.test', 'api', AuthDriver.Default);
+		Orion.clearHeaders();
+		Orion.setHeader('x-custom-header', 'patch-value');
+
+		const httpClient = Orion.makeHttpClient();
+		await httpClient.patch('/test-endpoint', { data: 'test' });
+
+		const requests = server.pretender.handledRequests;
+		expect(requests).toHaveLength(1);
+		expect(requests[0].requestHeaders).toMatchObject({
+			'x-custom-header': 'patch-value'
+		});
+	});
+
+	test('custom headers are sent with DELETE requests', async () => {
+		Orion.init('https://api-mock.test', 'api', AuthDriver.Default);
+		Orion.clearHeaders();
+		Orion.setHeader('x-custom-header', 'delete-value');
+
+		const httpClient = Orion.makeHttpClient();
+		await httpClient.delete('/test-endpoint');
+
+		const requests = server.pretender.handledRequests;
+		expect(requests).toHaveLength(1);
+		expect(requests[0].requestHeaders).toMatchObject({
+			'x-custom-header': 'delete-value'
+		});
+	});
 });

--- a/tests/unit/orion.test.ts
+++ b/tests/unit/orion.test.ts
@@ -3,6 +3,11 @@ import { AuthDriver } from '../../src/drivers/default/enums/authDriver';
 import axios from 'axios';
 
 describe('Orion tests', () => {
+	beforeEach(() => {
+		Orion.clearHeaders();
+		Orion.withoutToken();
+	});
+
 	test('initialization', () => {
 		Orion.init('https://example.com', 'custom-prefix', AuthDriver.Passport, 'test-token');
 
@@ -61,5 +66,117 @@ describe('Orion tests', () => {
 		});
 
 		expect(Orion.makeHttpClient().getAxios().defaults.baseURL).toBe('https://custom.com');
+	});
+
+	test('setting single custom header', () => {
+		Orion.setHeader('x-custom-header', 'header value');
+
+		expect(Orion.getCustomHeaders()).toEqual({
+			'x-custom-header': 'header value'
+		});
+	});
+
+	test('setting multiple custom headers', () => {
+		Orion.setHeaders({
+			'x-custom-header': 'header value',
+			'x-custom-header2': 'header value2'
+		});
+
+		expect(Orion.getCustomHeaders()).toEqual({
+			'x-custom-header': 'header value',
+			'x-custom-header2': 'header value2'
+		});
+	});
+
+	test('merging custom headers with existing ones', () => {
+		Orion.setHeader('x-custom-header', 'header value');
+		Orion.setHeaders({
+			'x-custom-header2': 'header value2',
+			'x-custom-header3': 'header value3'
+		});
+
+		expect(Orion.getCustomHeaders()).toEqual({
+			'x-custom-header': 'header value',
+			'x-custom-header2': 'header value2',
+			'x-custom-header3': 'header value3'
+		});
+	});
+
+	test('overwriting existing header with setHeader', () => {
+		Orion.setHeader('x-custom-header', 'original value');
+		Orion.setHeader('x-custom-header', 'new value');
+
+		expect(Orion.getCustomHeaders()).toEqual({
+			'x-custom-header': 'new value'
+		});
+	});
+
+	test('overwriting existing header with setHeaders', () => {
+		Orion.setHeader('x-custom-header', 'original value');
+		Orion.setHeaders({
+			'x-custom-header': 'new value',
+			'x-custom-header2': 'another value'
+		});
+
+		expect(Orion.getCustomHeaders()).toEqual({
+			'x-custom-header': 'new value',
+			'x-custom-header2': 'another value'
+		});
+	});
+
+	test('clearing all custom headers', () => {
+		Orion.setHeaders({
+			'x-custom-header': 'header value',
+			'x-custom-header2': 'header value2'
+		});
+		Orion.clearHeaders();
+
+		expect(Orion.getCustomHeaders()).toEqual({});
+	});
+
+	test('custom headers are included in http client config', () => {
+		Orion.setHeaders({
+			'x-custom-header': 'header value',
+			'x-custom-header2': 'header value2'
+		});
+
+		const config = Orion.getHttpClientConfig();
+		expect(config.headers).toEqual({
+			'x-custom-header': 'header value',
+			'x-custom-header2': 'header value2'
+		});
+	});
+
+	test('custom headers work with authorization token', () => {
+		Orion.setToken('test-token');
+		Orion.setHeaders({
+			'x-custom-header': 'header value',
+			'x-custom-header2': 'header value2'
+		});
+
+		const config = Orion.getHttpClientConfig();
+		expect(config.headers).toEqual({
+			'x-custom-header': 'header value',
+			'x-custom-header2': 'header value2',
+			'Authorization': 'Bearer test-token'
+		});
+	});
+
+	test('chaining methods works correctly', () => {
+		const result = Orion
+			.setHeader('x-custom-header', 'header value');
+
+		Orion.setToken('test-token');
+
+		Orion.setHeaders({
+			'x-custom-header2': 'header value2'
+		});
+
+		expect(result).toBe(Orion);
+		expect(Orion.getCustomHeaders()).toEqual({
+			'x-custom-header': 'header value',
+			'x-custom-header2': 'header value2'
+		});
+		expect(Orion.getToken()).toBe('test-token');
 	});
 });


### PR DESCRIPTION
Introduce methods (`setHeader`, `setHeaders`, `getCustomHeaders`, `clearHeaders`) to enable developers to easily add and manage custom HTTP headers for requests.

---
<a href="https://cursor.com/background-agent?bcId=bc-8d2c3cea-4308-4d24-b823-3d33441ab34e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8d2c3cea-4308-4d24-b823-3d33441ab34e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

