### PR TITLE
Add custom request headers

### DIFF
--- a/FEATURE_SUMMARY.md
+++ b/FEATURE_SUMMARY.md
@@ -1,0 +1,106 @@
+# Header Management Feature Implementation
+
+## Overview
+This PR adds comprehensive header management functionality to the Laravel Orion TypeScript SDK, allowing developers to set custom headers on HTTP requests similar to the existing token management.
+
+## New Methods Added
+
+### `Orion.setHeader(name: string, value: string): Orion`
+Sets a single custom header that will be included in all HTTP requests.
+
+```typescript
+Orion.setHeader('x-custom-header', 'header value');
+```
+
+### `Orion.setHeaders(headers: Record<string, string>): Orion`
+Sets multiple custom headers at once. Merges with existing headers, overwriting any with the same name.
+
+```typescript
+Orion.setHeaders({
+    'x-custom-header': 'header value',
+    'x-custom-header2': 'header value2',
+});
+```
+
+### `Orion.getHeaders(): Record<string, string>`
+Returns a copy of all currently set custom headers.
+
+```typescript
+const headers = Orion.getHeaders();
+```
+
+### `Orion.removeHeader(name: string): Orion`
+Removes a specific custom header.
+
+```typescript
+Orion.removeHeader('x-custom-header');
+```
+
+### `Orion.clearHeaders(): Orion`
+Clears all custom headers.
+
+```typescript
+Orion.clearHeaders();
+```
+
+## Key Features
+
+1. **Method Chaining**: All methods return the Orion class for fluent API usage
+2. **Auth Token Priority**: Authentication tokens take precedence over custom Authorization headers
+3. **Automatic Integration**: Custom headers are automatically included in all HTTP requests
+4. **Immutable Getters**: `getHeaders()` returns a copy to prevent external modification
+5. **Config Rebuilding**: HTTP client configuration is automatically rebuilt when headers change
+
+## Implementation Details
+
+- Added `customHeaders` static property to store headers
+- Modified `buildHttpClientConfig()` to merge custom headers with auth headers
+- All header methods trigger config rebuilding for immediate effect
+- Headers are stored as `Record<string, string>` for type safety
+
+## Testing
+
+Comprehensive unit tests added covering:
+- Setting single and multiple headers
+- Header merging and overwriting behavior
+- Integration with auth tokens
+- Method chaining functionality
+- Config rebuilding verification
+- Immutable getter behavior
+- Header removal and clearing
+
+All existing tests continue to pass, ensuring backward compatibility.
+
+## Usage Examples
+
+```typescript
+// Initialize Orion
+Orion.init('https://api.example.com', 'api', AuthDriver.Default, 'auth-token');
+
+// Set individual headers
+Orion.setHeader('x-api-version', '1.0')
+      .setHeader('x-client-id', 'my-app');
+
+// Set multiple headers at once
+Orion.setHeaders({
+    'x-custom-header': 'value1',
+    'x-another-header': 'value2'
+});
+
+// Use with models (headers automatically included)
+const users = await User.all();
+
+// Manage headers
+const currentHeaders = Orion.getHeaders();
+Orion.removeHeader('x-api-version');
+Orion.clearHeaders();
+```
+
+## Files Modified
+
+- `src/orion.ts`: Added header management methods and storage
+- `tests/unit/orion.test.ts`: Added comprehensive test suite for header functionality
+
+## Backward Compatibility
+
+This feature is fully backward compatible. No existing functionality is changed or removed.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@tailflow/laravel-orion",
-	"version": "4.0.0",
+	"version": "4.1.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@tailflow/laravel-orion",
-			"version": "4.0.0",
+			"version": "4.1.0",
 			"license": "MIT",
 			"dependencies": {
 				"axios": "^1.6.0"

--- a/src/orion.ts
+++ b/src/orion.ts
@@ -7,6 +7,7 @@ export class Orion {
 	protected static prefix: string;
 	protected static authDriver: AuthDriver;
 	protected static token: string | null = null;
+	protected static customHeaders: Record<string, string> = {};
 
 	protected static httpClientConfig: AxiosRequestConfig;
 	protected static makeHttpClientCallback: (() => AxiosInstance) | null = null;
@@ -76,6 +77,34 @@ export class Orion {
 		return Orion.token;
 	}
 
+	public static setHeader(name: string, value: string): Orion {
+		Orion.customHeaders[name] = value;
+		Orion.httpClientConfig = Orion.buildHttpClientConfig();
+		return Orion;
+	}
+
+	public static setHeaders(headers: Record<string, string>): Orion {
+		Orion.customHeaders = { ...Orion.customHeaders, ...headers };
+		Orion.httpClientConfig = Orion.buildHttpClientConfig();
+		return Orion;
+	}
+
+	public static getHeaders(): Record<string, string> {
+		return { ...Orion.customHeaders };
+	}
+
+	public static removeHeader(name: string): Orion {
+		delete Orion.customHeaders[name];
+		Orion.httpClientConfig = Orion.buildHttpClientConfig();
+		return Orion;
+	}
+
+	public static clearHeaders(): Orion {
+		Orion.customHeaders = {};
+		Orion.httpClientConfig = Orion.buildHttpClientConfig();
+		return Orion;
+	}
+
 	public static getHttpClientConfig(): AxiosRequestConfig {
 		return this.httpClientConfig;
 	}
@@ -108,10 +137,14 @@ export class Orion {
 			withCredentials: Orion.getAuthDriver() === AuthDriver.Sanctum,
 		};
 
+		const headers: Record<string, string> = { ...Orion.customHeaders };
+
 		if (Orion.getToken()) {
-			config.headers = {
-				Authorization: `Bearer ${Orion.getToken()}`,
-			};
+			headers.Authorization = `Bearer ${Orion.getToken()}`;
+		}
+
+		if (Object.keys(headers).length > 0) {
+			config.headers = headers;
 		}
 
 		return config;

--- a/tests/unit/orion.test.ts
+++ b/tests/unit/orion.test.ts
@@ -62,4 +62,140 @@ describe('Orion tests', () => {
 
 		expect(Orion.makeHttpClient().getAxios().defaults.baseURL).toBe('https://custom.com');
 	});
+
+	describe('header management', () => {
+		beforeEach(() => {
+			Orion.clearHeaders();
+			Orion.withoutToken();
+		});
+
+		test('setting a single header', () => {
+			Orion.setHeader('x-custom-header', 'header value');
+
+			const headers = Orion.getHeaders();
+			expect(headers['x-custom-header']).toBe('header value');
+		});
+
+		test('setting multiple headers at once', () => {
+			Orion.setHeaders({
+				'x-custom-header': 'header value',
+				'x-custom-header2': 'header value2',
+			});
+
+			const headers = Orion.getHeaders();
+			expect(headers['x-custom-header']).toBe('header value');
+			expect(headers['x-custom-header2']).toBe('header value2');
+		});
+
+		test('setHeaders merges with existing headers', () => {
+			Orion.setHeader('x-existing-header', 'existing value');
+			Orion.setHeaders({
+				'x-custom-header': 'header value',
+				'x-custom-header2': 'header value2',
+			});
+
+			const headers = Orion.getHeaders();
+			expect(headers['x-existing-header']).toBe('existing value');
+			expect(headers['x-custom-header']).toBe('header value');
+			expect(headers['x-custom-header2']).toBe('header value2');
+		});
+
+		test('setHeaders overwrites existing headers with same name', () => {
+			Orion.setHeader('x-custom-header', 'original value');
+			Orion.setHeaders({
+				'x-custom-header': 'new value',
+			});
+
+			const headers = Orion.getHeaders();
+			expect(headers['x-custom-header']).toBe('new value');
+		});
+
+		test('getting headers returns a copy', () => {
+			Orion.setHeader('x-custom-header', 'header value');
+			
+			const headers = Orion.getHeaders();
+			headers['x-modified'] = 'modified value';
+
+			const originalHeaders = Orion.getHeaders();
+			expect(originalHeaders['x-modified']).toBeUndefined();
+		});
+
+		test('removing a specific header', () => {
+			Orion.setHeaders({
+				'x-custom-header': 'header value',
+				'x-custom-header2': 'header value2',
+			});
+
+			Orion.removeHeader('x-custom-header');
+
+			const headers = Orion.getHeaders();
+			expect(headers['x-custom-header']).toBeUndefined();
+			expect(headers['x-custom-header2']).toBe('header value2');
+		});
+
+		test('clearing all headers', () => {
+			Orion.setHeaders({
+				'x-custom-header': 'header value',
+				'x-custom-header2': 'header value2',
+			});
+
+			Orion.clearHeaders();
+
+			const headers = Orion.getHeaders();
+			expect(Object.keys(headers)).toHaveLength(0);
+		});
+
+		test('custom headers are included in http client config', () => {
+			Orion.init('https://example.com');
+			Orion.setHeaders({
+				'x-custom-header': 'header value',
+				'x-custom-header2': 'header value2',
+			});
+
+			const config = Orion.getHttpClientConfig();
+			expect(config.headers?.['x-custom-header']).toBe('header value');
+			expect(config.headers?.['x-custom-header2']).toBe('header value2');
+		});
+
+		test('custom headers work together with auth token', () => {
+			Orion.init('https://example.com', 'api', AuthDriver.Default, 'test-token');
+			Orion.setHeader('x-custom-header', 'header value');
+
+			const config = Orion.getHttpClientConfig();
+			expect(config.headers?.['Authorization']).toBe('Bearer test-token');
+			expect(config.headers?.['x-custom-header']).toBe('header value');
+		});
+
+		test('auth token takes precedence over custom Authorization header', () => {
+			Orion.init('https://example.com', 'api', AuthDriver.Default, 'test-token');
+			Orion.setHeader('Authorization', 'Custom auth');
+
+			const config = Orion.getHttpClientConfig();
+			expect(config.headers?.['Authorization']).toBe('Bearer test-token');
+		});
+
+		test('method chaining works for header methods', () => {
+			const result1 = Orion.setHeader('x-header1', 'value1');
+			const result2 = Orion.setHeaders({ 'x-header2': 'value2' });
+			const result3 = Orion.removeHeader('x-header1');
+			const result4 = Orion.clearHeaders();
+
+			expect(result1).toBe(Orion);
+			expect(result2).toBe(Orion);
+			expect(result3).toBe(Orion);
+			expect(result4).toBe(Orion);
+			expect(Object.keys(Orion.getHeaders())).toHaveLength(0);
+		});
+
+		test('http client config is rebuilt when headers change', () => {
+			Orion.init('https://example.com');
+			
+			const configBefore = Orion.getHttpClientConfig();
+			Orion.setHeader('x-custom-header', 'header value');
+			const configAfter = Orion.getHttpClientConfig();
+
+			expect(configBefore).not.toBe(configAfter);
+			expect(configAfter.headers?.['x-custom-header']).toBe('header value');
+		});
+	});
 });


### PR DESCRIPTION
Adds methods (`setHeader`, `setHeaders`, `getHeaders`, `removeHeader`, `clearHeaders`) to the `Orion` class to allow developers to manage custom HTTP request headers.

This feature provides developers with the flexibility to include specific headers in their API requests. Authentication tokens take precedence over custom `Authorization` headers to ensure consistent authentication behavior.

---
<a href="https://cursor.com/background-agent?bcId=bc-4562a129-4c1b-451b-93e6-410ce7c1a510"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4562a129-4c1b-451b-93e6-410ce7c1a510"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

