### PR TITLE
Add custom request headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,62 @@ Laravel Orion TypeScript SDK allows you to build expressive frontend application
 ## Official Documentation
 
 Documentation for Laravel Orion and its TypeScript SDK can be found on the [website](https://tailflow.github.io/laravel-orion-docs/).
+
+## Custom Headers
+
+Laravel Orion TypeScript SDK now supports adding custom headers to all requests. This is useful when you need to include additional headers like API keys, request IDs, or other custom headers required by your application.
+
+### Setting a Single Header
+
+```typescript
+import { Orion } from '@tailflow/laravel-orion';
+
+// Set a single custom header
+Orion.setHeader('X-Custom-Header', 'header-value');
+```
+
+### Setting Multiple Headers
+
+```typescript
+// Set multiple headers at once
+Orion.setHeaders({
+    'X-Custom-Header': 'header-value',
+    'X-Another-Header': 'another-value',
+    'X-Request-ID': 'unique-request-id'
+});
+```
+
+### Method Chaining
+
+All header methods support chaining for a fluent interface:
+
+```typescript
+Orion
+    .setHeader('X-First', 'first-value')
+    .setHeaders({
+        'X-Second': 'second-value',
+        'X-Third': 'third-value'
+    })
+    .setToken('auth-token');
+```
+
+### Clearing Headers
+
+```typescript
+// Remove all custom headers
+Orion.clearHeaders();
+
+// Get current headers
+const headers = Orion.getHeaders();
+```
+
+### Usage with Authentication
+
+Custom headers work seamlessly with existing authentication methods:
+
+```typescript
+Orion.setToken('your-auth-token');
+Orion.setHeader('X-Custom-Header', 'custom-value');
+
+// Both Authorization and X-Custom-Header will be included in requests
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@tailflow/laravel-orion",
-	"version": "4.0.0",
+	"version": "4.1.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@tailflow/laravel-orion",
-			"version": "4.0.0",
+			"version": "4.1.0",
 			"license": "MIT",
 			"dependencies": {
 				"axios": "^1.6.0"

--- a/src/orion.ts
+++ b/src/orion.ts
@@ -7,6 +7,7 @@ export class Orion {
 	protected static prefix: string;
 	protected static authDriver: AuthDriver;
 	protected static token: string | null = null;
+	protected static customHeaders: Record<string, string> = {};
 
 	protected static httpClientConfig: AxiosRequestConfig;
 	protected static makeHttpClientCallback: (() => AxiosInstance) | null = null;
@@ -76,6 +77,28 @@ export class Orion {
 		return Orion.token;
 	}
 
+	public static setHeader(key: string, value: string): typeof Orion {
+		Orion.customHeaders[key] = value;
+		Orion.httpClientConfig = Orion.buildHttpClientConfig();
+		return Orion;
+	}
+
+	public static setHeaders(headers: Record<string, string>): typeof Orion {
+		Orion.customHeaders = { ...Orion.customHeaders, ...headers };
+		Orion.httpClientConfig = Orion.buildHttpClientConfig();
+		return Orion;
+	}
+
+	public static getHeaders(): Record<string, string> {
+		return Orion.customHeaders;
+	}
+
+	public static clearHeaders(): typeof Orion {
+		Orion.customHeaders = {};
+		Orion.httpClientConfig = Orion.buildHttpClientConfig();
+		return Orion;
+	}
+
 	public static getHttpClientConfig(): AxiosRequestConfig {
 		return this.httpClientConfig;
 	}
@@ -108,10 +131,17 @@ export class Orion {
 			withCredentials: Orion.getAuthDriver() === AuthDriver.Sanctum,
 		};
 
+		// Initialize headers object
+		config.headers = {};
+
+		// Add Authorization header if token is set
 		if (Orion.getToken()) {
-			config.headers = {
-				Authorization: `Bearer ${Orion.getToken()}`,
-			};
+			config.headers.Authorization = `Bearer ${Orion.getToken()}`;
+		}
+
+		// Add custom headers
+		if (Object.keys(Orion.customHeaders).length > 0) {
+			config.headers = { ...config.headers, ...Orion.customHeaders };
 		}
 
 		return config;

--- a/tests/integration/httpClient.test.ts
+++ b/tests/integration/httpClient.test.ts
@@ -22,4 +22,64 @@ describe('HttpClient tests', () => {
 		const requests = server.pretender.handledRequests;
 		expect(requests[0].requestHeaders['Authorization']).toStrictEqual('Bearer test');
 	});
+
+	test('using custom headers with setHeader', async () => {
+		server.schema.posts.create({ title: 'Test Post' });
+
+		Orion.clearHeaders();
+		Orion.setHeader('X-Custom-Header', 'test-value');
+		Orion.setHeader('X-Another-Header', 'another-value');
+		
+		await Orion.makeHttpClient().request('/posts', HttpMethod.GET);
+
+		const requests = server.pretender.handledRequests;
+		expect(requests[0].requestHeaders['X-Custom-Header']).toStrictEqual('test-value');
+		expect(requests[0].requestHeaders['X-Another-Header']).toStrictEqual('another-value');
+	});
+
+	test('using custom headers with setHeaders', async () => {
+		server.schema.posts.create({ title: 'Test Post' });
+
+		Orion.clearHeaders();
+		Orion.setHeaders({
+			'X-Custom-Header': 'test-value',
+			'X-Another-Header': 'another-value'
+		});
+		
+		await Orion.makeHttpClient().request('/posts', HttpMethod.GET);
+
+		const requests = server.pretender.handledRequests;
+		expect(requests[0].requestHeaders['X-Custom-Header']).toStrictEqual('test-value');
+		expect(requests[0].requestHeaders['X-Another-Header']).toStrictEqual('another-value');
+	});
+
+	test('combining bearer token with custom headers', async () => {
+		server.schema.posts.create({ title: 'Test Post' });
+
+		Orion.clearHeaders();
+		Orion.setToken('test-token');
+		Orion.setHeader('X-Custom-Header', 'custom-value');
+		
+		await Orion.makeHttpClient().request('/posts', HttpMethod.GET);
+
+		const requests = server.pretender.handledRequests;
+		expect(requests[0].requestHeaders['Authorization']).toStrictEqual('Bearer test-token');
+		expect(requests[0].requestHeaders['X-Custom-Header']).toStrictEqual('custom-value');
+	});
+
+	test('clearing headers removes them from requests', async () => {
+		server.schema.posts.create({ title: 'Test Post' });
+
+		Orion.setHeaders({
+			'X-Custom-Header': 'test-value',
+			'X-Another-Header': 'another-value'
+		});
+		Orion.clearHeaders();
+		
+		await Orion.makeHttpClient().request('/posts', HttpMethod.GET);
+
+		const requests = server.pretender.handledRequests;
+		expect(requests[0].requestHeaders['X-Custom-Header']).toBeUndefined();
+		expect(requests[0].requestHeaders['X-Another-Header']).toBeUndefined();
+	});
 });

--- a/tests/unit/orion.test.ts
+++ b/tests/unit/orion.test.ts
@@ -62,4 +62,91 @@ describe('Orion tests', () => {
 
 		expect(Orion.makeHttpClient().getAxios().defaults.baseURL).toBe('https://custom.com');
 	});
+
+	test('setting a single custom header', () => {
+		Orion.clearHeaders();
+		Orion.setHeader('X-Custom-Header', 'test-value');
+
+		expect(Orion.getHeaders()).toEqual({
+			'X-Custom-Header': 'test-value'
+		});
+
+		const config = Orion.getHttpClientConfig();
+		expect(config.headers).toHaveProperty('X-Custom-Header', 'test-value');
+	});
+
+	test('setting multiple custom headers at once', () => {
+		Orion.clearHeaders();
+		Orion.setHeaders({
+			'X-Custom-Header': 'test-value',
+			'X-Another-Header': 'another-value'
+		});
+
+		expect(Orion.getHeaders()).toEqual({
+			'X-Custom-Header': 'test-value',
+			'X-Another-Header': 'another-value'
+		});
+
+		const config = Orion.getHttpClientConfig();
+		expect(config.headers).toHaveProperty('X-Custom-Header', 'test-value');
+		expect(config.headers).toHaveProperty('X-Another-Header', 'another-value');
+	});
+
+	test('adding headers incrementally', () => {
+		Orion.clearHeaders();
+		Orion.setHeader('X-First', 'first');
+		Orion.setHeader('X-Second', 'second');
+
+		expect(Orion.getHeaders()).toEqual({
+			'X-First': 'first',
+			'X-Second': 'second'
+		});
+	});
+
+	test('overwriting existing header', () => {
+		Orion.clearHeaders();
+		Orion.setHeader('X-Custom', 'old-value');
+		Orion.setHeader('X-Custom', 'new-value');
+
+		expect(Orion.getHeaders()['X-Custom']).toBe('new-value');
+	});
+
+	test('clearing all custom headers', () => {
+		Orion.setHeaders({
+			'X-Custom-Header': 'test-value',
+			'X-Another-Header': 'another-value'
+		});
+		Orion.clearHeaders();
+
+		expect(Orion.getHeaders()).toEqual({});
+		
+		const config = Orion.getHttpClientConfig();
+		expect(config.headers).not.toHaveProperty('X-Custom-Header');
+		expect(config.headers).not.toHaveProperty('X-Another-Header');
+	});
+
+	test('custom headers work with authorization token', () => {
+		Orion.clearHeaders();
+		Orion.setToken('test-token');
+		Orion.setHeader('X-Custom-Header', 'test-value');
+
+		const config = Orion.getHttpClientConfig();
+		expect(config.headers).toHaveProperty('Authorization', 'Bearer test-token');
+		expect(config.headers).toHaveProperty('X-Custom-Header', 'test-value');
+	});
+
+	test('method chaining works with header methods', () => {
+		Orion.clearHeaders();
+		const result = Orion.setHeader('X-First', 'first').setHeaders({
+			'X-Second': 'second',
+			'X-Third': 'third'
+		});
+
+		expect(result).toBe(Orion);
+		expect(Orion.getHeaders()).toEqual({
+			'X-First': 'first',
+			'X-Second': 'second',
+			'X-Third': 'third'
+		});
+	});
 });


### PR DESCRIPTION
Add `setHeader`, `setHeaders`, `getHeaders`, and `clearHeaders` methods to Orion to allow developers to easily include custom HTTP headers in requests.

---
<a href="https://cursor.com/background-agent?bcId=bc-dbdd2125-6c20-4563-b752-89bee562b888"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-dbdd2125-6c20-4563-b752-89bee562b888"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

