### PR TITLE
Add custom request headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,20 @@ Laravel Orion TypeScript SDK allows you to build expressive frontend application
 ## Official Documentation
 
 Documentation for Laravel Orion and its TypeScript SDK can be found on the [website](https://tailflow.github.io/laravel-orion-docs/).
+
+### Custom request headers
+
+You can set additional request headers globally:
+
+```ts
+import { Orion } from '@tailflow/laravel-orion';
+
+// Single header
+Orion.setHeader('x-custom-header', 'header value');
+
+// Multiple headers
+Orion.setHeaders({
+  'x-custom-header': 'header value',
+  'x-custom-header2': 'header value2',
+});
+```

--- a/src/orion.ts
+++ b/src/orion.ts
@@ -7,6 +7,7 @@ export class Orion {
 	protected static prefix: string;
 	protected static authDriver: AuthDriver;
 	protected static token: string | null = null;
+	protected static headers: Record<string, string> = {};
 
 	protected static httpClientConfig: AxiosRequestConfig;
 	protected static makeHttpClientCallback: (() => AxiosInstance) | null = null;
@@ -108,13 +109,33 @@ export class Orion {
 			withCredentials: Orion.getAuthDriver() === AuthDriver.Sanctum,
 		};
 
+		const headers: Record<string, string> = {};
+
 		if (Orion.getToken()) {
-			config.headers = {
-				Authorization: `Bearer ${Orion.getToken()}`,
-			};
+			headers.Authorization = `Bearer ${Orion.getToken()}`;
+		}
+
+		if (Orion.headers && Object.keys(Orion.headers).length > 0) {
+			Object.assign(headers, Orion.headers);
+		}
+
+		if (Object.keys(headers).length > 0) {
+			config.headers = headers;
 		}
 
 		return config;
+	}
+
+	public static setHeader(name: string, value: string): Orion {
+		Orion.headers = Object.assign({}, Orion.headers, { [name]: value });
+		Orion.httpClientConfig = Orion.buildHttpClientConfig();
+		return Orion;
+	}
+
+	public static setHeaders(headers: Record<string, string>): Orion {
+		Orion.headers = headers || {};
+		Orion.httpClientConfig = Orion.buildHttpClientConfig();
+		return Orion;
 	}
 
 	public static async csrf(): Promise<void> {

--- a/tests/integration/httpClient.test.ts
+++ b/tests/integration/httpClient.test.ts
@@ -22,4 +22,46 @@ describe('HttpClient tests', () => {
 		const requests = server.pretender.handledRequests;
 		expect(requests[0].requestHeaders['Authorization']).toStrictEqual('Bearer test');
 	});
+
+	test('using single custom header', async () => {
+		server.schema.posts.create({ title: 'Test Post' });
+
+		Orion.withoutToken();
+		Orion.setHeaders({});
+		Orion.setHeader('x-custom-header', 'header value');
+
+		await Orion.makeHttpClient().request('/posts', HttpMethod.GET);
+
+		const requests = server.pretender.handledRequests;
+		expect(requests[0].requestHeaders['x-custom-header']).toStrictEqual('header value');
+	});
+
+	test('using multiple custom headers', async () => {
+		server.schema.posts.create({ title: 'Test Post' });
+
+		Orion.withoutToken();
+		Orion.setHeaders({
+			'x-custom-header': 'header value',
+			'x-custom-header2': 'header value2',
+		});
+
+		await Orion.makeHttpClient().request('/posts', HttpMethod.GET);
+
+		const requests = server.pretender.handledRequests;
+		expect(requests[0].requestHeaders['x-custom-header']).toStrictEqual('header value');
+		expect(requests[0].requestHeaders['x-custom-header2']).toStrictEqual('header value2');
+	});
+
+	test('merging custom header with bearer token', async () => {
+		server.schema.posts.create({ title: 'Test Post' });
+
+		Orion.setToken('test');
+		Orion.setHeader('x-custom-header', 'header value');
+
+		await Orion.makeHttpClient().request('/posts', HttpMethod.GET);
+
+		const requests = server.pretender.handledRequests;
+		expect(requests[0].requestHeaders['Authorization']).toStrictEqual('Bearer test');
+		expect(requests[0].requestHeaders['x-custom-header']).toStrictEqual('header value');
+	});
 });

--- a/tests/unit/orion.test.ts
+++ b/tests/unit/orion.test.ts
@@ -44,6 +44,24 @@ describe('Orion tests', () => {
 		expect(Orion.getToken()).toBeNull();
 	});
 
+	test('setting single custom header', () => {
+		Orion.setHeader('x-custom-header', 'header value');
+
+		const config = Orion.getHttpClientConfig();
+		expect(config.headers && (config.headers as any)['x-custom-header']).toBe('header value');
+	});
+
+	test('setting multiple custom headers', () => {
+		Orion.setHeaders({
+			'x-custom-header': 'header value',
+			'x-custom-header2': 'header value2',
+		});
+
+		const config = Orion.getHttpClientConfig();
+		expect(config.headers && (config.headers as any)['x-custom-header']).toBe('header value');
+		expect(config.headers && (config.headers as any)['x-custom-header2']).toBe('header value2');
+	});
+
 	test('appending slash to the end when getting api url', () => {
 		Orion.setBaseUrl('https://example.com/api');
 


### PR DESCRIPTION
Add `Orion.setHeader()` and `Orion.setHeaders()` methods to allow developers to include custom HTTP headers in requests.

---
<a href="https://cursor.com/background-agent?bcId=bc-c6197845-c06a-4b80-993f-fa3701298f78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c6197845-c06a-4b80-993f-fa3701298f78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

